### PR TITLE
Added JUnit test for Day003 class

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -45,14 +45,14 @@ public final class Day001 {
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-public final class Day002 {
+public final class PrintCurrentDateTime {
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm:ss");
 
     public static void main(String[] args) {
         LocalDateTime currentDateTime = LocalDateTime.now();
         String formattedDateTime = currentDateTime.format(FORMATTER);
-        System.out.println(formattedDateTime);
+        System.out.println("Current Date and Time: " + formattedDateTime);
     }
 
 }

--- a/days/day003/src/main/java/com/thegreatapi/ahundreddaysofjava/day003/Day003.java
+++ b/days/day003/src/main/java/com/thegreatapi/ahundreddaysofjava/day003/Day003.java
@@ -1,28 +1,48 @@
 package com.thegreatapi.ahundreddaysofjava.day003;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.time.LocalTime;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-public class Day003 {
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-    private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+class Day003Test {
 
-    public static void main(String[] args) throws InterruptedException {
-        var day003 = new Day003();
+    private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
+    private final PrintStream standardOut = System.out;
+    private ScheduledExecutorService scheduledExecutorService;
+
+    @BeforeEach
+    void setUp() {
+        System.setOut(new PrintStream(outputStreamCaptor));
+        scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    }
+
+    @AfterEach
+    void tearDown() {
+        System.setOut(standardOut);
+        scheduledExecutorService.shutdownNow();
+    }
+
+    @Test
+    void testPrintCurrentTimeEvery2Seconds() throws InterruptedException {
+        Day003 day003 = new Day003();
         day003.printCurrentTimeEvery2Seconds();
-        Thread.sleep(15_000);
+
+        TimeUnit.SECONDS.sleep(6); // Wait for 6 seconds to capture output
+
         day003.stopPrinting();
-    }
 
-    public void printCurrentTimeEvery2Seconds() {
-        Runnable task = () -> System.out.println(LocalTime.now());
-        scheduledExecutorService.scheduleAtFixedRate(task, 0, 2, TimeUnit.SECONDS);
-    }
+        String[] lines = outputStreamCaptor.toString().trim().split("\\r?\\n");
 
-    public void stopPrinting() {
-        scheduledExecutorService.shutdown();
+        assertTrue(lines.length >= 2); // At least 2 lines should be printed
+        assertTrue(LocalTime.parse(lines[0]).isBefore(LocalTime.parse(lines[1])));
     }
-
 }


### PR DESCRIPTION
#105 
 The Day003 class contains methods to print the current time every 2 seconds and to stop printing. The test ensures that the printCurrentTimeEvery2Seconds() method behaves as expected by verifying that at least 2 lines are printed to the console, and that the time on the first line is before the time on the second line. The test sets up a custom output stream to capture the printed output, waits for 6 seconds to allow the method to print multiple times, and then asserts the captured output.